### PR TITLE
feat:  allow the title to have different levels

### DIFF
--- a/src/lib/components/atoms/Title.svelte
+++ b/src/lib/components/atoms/Title.svelte
@@ -1,10 +1,16 @@
 <script>
-  import { CheckedIcon } from "$lib";
 
   let { headingText, Icon, className, level = "h1" } = $props();
+
+  const levels = ["h1", "h2", "h3", "h4", "h5", "h6"];
+  const CurrentLevel = $derived(level);
+
+  const validateLevel = (level) => {
+    return levels.includes(level) ? level : "h1";
+  };
 </script>
 
-<svelte:element this={level} class={className}>
+<svelte:element this={validateLevel(level)} class={className}>
   {#if Icon}
     <Icon class="icon" />
   {/if}

--- a/src/lib/components/atoms/Title.svelte
+++ b/src/lib/components/atoms/Title.svelte
@@ -6,9 +6,11 @@
   const validateLevel = (level) => {
     return levels.includes(level) ? level : "h1";
   };
+
+  const validatedLevel = $derived(validateLevel(level));
 </script>
 
-<svelte:element this={validateLevel(level)} class={className}>
+<svelte:element this={validatedLevel} class={className}>
   {#if Icon}
     <Icon class="icon" />
   {/if}

--- a/src/lib/components/atoms/Title.svelte
+++ b/src/lib/components/atoms/Title.svelte
@@ -1,23 +1,22 @@
 <script>
-    import { CheckedIcon } from "$lib";
+  import { CheckedIcon } from "$lib";
 
-    let { headingText, Icon } = $props();
+  let { headingText, Icon, className, level = "h1" } = $props();
 </script>
 
-
-<div class="heading">
-    {#if Icon}
-        <Icon class="icon"/>
-    {/if}
-    <h2 class="h1">{headingText}</h2>
-</div>
+<svelte:element this={level} class={className}>
+  {#if Icon}
+    <Icon class="icon" />
+  {/if}
+  {headingText}
+</svelte:element>
 
 <style>
-    .heading {
-        display: flex;
-        flex-direction: row;
-        gap: var(--spacing-sm);
-        align-items: center;
-        padding: var(--spacing-md) var(--spacing-xs) var(--spacing-xl) 0rem;
-    }
+  .heading {
+    display: flex;
+    flex-direction: row;
+    gap: var(--spacing-sm);
+    align-items: center;
+    padding: var(--spacing-md) var(--spacing-xs) var(--spacing-xl) 0rem;
+  }
 </style>

--- a/src/lib/components/atoms/Title.svelte
+++ b/src/lib/components/atoms/Title.svelte
@@ -1,9 +1,7 @@
 <script>
-
   let { headingText, Icon, className, level = "h1" } = $props();
 
   const levels = ["h1", "h2", "h3", "h4", "h5", "h6"];
-  const CurrentLevel = $derived(level);
 
   const validateLevel = (level) => {
     return levels.includes(level) ? level : "h1";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,7 +40,7 @@
   digital divide.
 </p>
 
-<Title headingText="This is an heading text" />
+<Title className='heading' level='h4' headingText="This is an heading text" />
 
 <section class="card-container">
     <InformationCard


### PR DESCRIPTION
## What does this change?

Resolves issue #2 

Allow the title to have different levels by passing it as a prop and using <svelte:element>

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Summary by Sourcery

Nieuwe functies:
- Ondersteuning voor een configureerbaar kopniveau en een aangepaste classnaam op de Title-component via props.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support configurable heading level and custom class name on the Title component via props.

</details>