### PR TITLE
feat: implement a reusable text (component/atom)

### DIFF
--- a/src/lib/components/atoms/Text.svelte
+++ b/src/lib/components/atoms/Text.svelte
@@ -1,0 +1,17 @@
+<script>
+  let { text, Icon, className } = $props();
+</script>
+
+<p class={className}>
+  {#if Icon}
+    <Icon class="icon" />
+  {/if}
+  {text}
+</p>
+
+<style>
+  .footer-text {
+    display: flex;
+    gap: 0.5rem;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import Title from "$lib/components/atoms/Title.svelte";
   import Link from "$lib/components/atoms/Link.svelte";
   import Footer from "$lib/components/organisms/Footer.svelte";
+  import Text from "$lib/components/atoms/text.svelte";
 
   // Icons
   import {
@@ -42,16 +43,25 @@
 
 <Title headingText="This is an heading text" />
 
+<Text
+  text="The findings of the project so far, demonstrate that digital tools and data
+  literacy are essential for improving working conditions and combating
+  exploitation."
+  className="footer-text"
+/>
+
 <section class="card-container">
-    <InformationCard
-        cardText="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
-    />
-    <InformationCard
-        cardText="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
-    />
-    <InformationCard
-     Icon={PhotoUpload}   cardTitle="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on." cardSubText="lorem10"
-    />
+  <InformationCard
+    cardText="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
+  />
+  <InformationCard
+    cardText="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
+  />
+  <InformationCard
+    Icon={PhotoUpload}
+    cardTitle="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
+    cardSubText="lorem10"
+  />
 
   <InformationCard
     cardText="Always keep ORIGINAL files (no edits/filters). Keep location and date/time on."
@@ -66,14 +76,14 @@
 
 <SelectButton />
 
-<Button buttonText="Discreet mode" buttonType="btn-white"/>
+<Button buttonText="Discreet mode" buttonType="btn-white" />
 <Button buttonText="Discreet mode" />
 
 <FileInput inputField="Photo or video (Camera)" />
 
 <Link text="I'm a link" className="footer-link" />
 
-<Footer/>
+<Footer />
 
 <style>
   .card-container {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
   import Title from "$lib/components/atoms/Title.svelte";
   import Link from "$lib/components/atoms/Link.svelte";
   import Footer from "$lib/components/organisms/Footer.svelte";
-  import Text from "$lib/components/atoms/text.svelte";
+  import Text from "$lib/components/atoms/Text.svelte";
 
   // Icons
   import {


### PR DESCRIPTION
## What does this change?

Resolves issue #39 

A reusable text component/atom  



## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [x] [User test]()
- [ ] [Accessibility test]()
- [x] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Summary by Sourcery

Voeg een herbruikbare tekst-atom toe en integreer deze in de lay-out van de hoofdpagina.

Nieuwe features:
- Introduceer een Text-atomcomponent die configureerbare tekst rendert met een optioneel pictogram en aangepaste styling.

Verbeteringen:
- Gebruik de nieuwe Text-atom op de hoofdpagina en ruim de markup-opmaak op voor bestaande componenten.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a reusable text atom and integrate it into the main page layout.

New Features:
- Introduce a Text atom component that renders configurable text with an optional icon and custom styling.

Enhancements:
- Use the new Text atom in the main page and clean up markup formatting for existing components.

</details>