### PR TITLE
fix: correct background image path in +page.svelte

### DIFF
--- a/src/routes/submit-proof/+page.svelte
+++ b/src/routes/submit-proof/+page.svelte
@@ -11,7 +11,7 @@ main {
     padding: 10% 0;
     display: grid;
     place-items: center;
-    background-image: url("src/lib/assets/img/HeaderBg.webp");
+    background-image: url("$lib/assets/img/HeaderBg.webp");
     background-size: cover;
     background-repeat: no-repeat;
     background-attachment: fixed;


### PR DESCRIPTION
## What does this change?
 fix the background image path 
 
 

